### PR TITLE
Fix grid reference during step updates

### DIFF
--- a/src/ColorWarGame.py
+++ b/src/ColorWarGame.py
@@ -585,7 +585,6 @@ class AISim:
         MAX_FACTIONS = 150
         total_cells = max(1, self.grid_width * self.grid_height)
         new_grid = [row[:] for row in self.grid]
-        self.grid = new_grid
 
         for y in range(self.grid_height):
             for x in range(self.grid_width):


### PR DESCRIPTION
## Summary
- stop replacing `self.grid` at the start of `step`
- keep the original grid reference until the update completes

## Testing
- `python -m py_compile src/ColorWarGame.py`
- `python -m py_compile tst.py`

------
https://chatgpt.com/codex/tasks/task_e_685422c1350c83229a21cfa06f5f469f