### PR TITLE
Add tests and dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ This will open a window and spawn a few random factions that expand each frame.
 ## Legacy Code
 
 The original experimental implementation lives in `src/ColorWarGame.py` and is retained for reference but it is quite large and unstructured.
+
+## Running Tests
+
+Install the development requirements:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Then execute the test suite with:
+
+```bash
+pytest
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+flake8

--- a/tests/test_theme_json.py
+++ b/tests/test_theme_json.py
@@ -1,0 +1,9 @@
+import json
+import os
+
+
+def test_fallback_theme_loads():
+    path = os.path.join('src', 'fallback_theme.json')
+    with open(path, 'r') as f:
+        data = json.load(f)
+    assert 'global' in data


### PR DESCRIPTION
## Summary
- test that `fallback_theme.json` loads
- add `pytest` and `flake8` to dev requirements
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542705a8908322be703f5ead107621